### PR TITLE
Add build workflow and clarify local setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build firmware
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sdcc make python3
+
+      - name: Build firmware
+        run: |
+          make clean
+          make
+          make wrapped
+
+      - name: Archive firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: asm2464pd-firmware
+          path: |
+            build/firmware.bin
+            build/firmware_wrapped.bin

--- a/README.md
+++ b/README.md
@@ -12,12 +12,26 @@ Open-source C firmware for the ASM2464PD USB4/Thunderbolt to NVMe bridge control
 
 ## Building
 
-Requires SDCC (Small Device C Compiler).
+### Prerequisites
+
+* [SDCC](https://sdcc.sourceforge.net/) (Small Device C Compiler)
+* GNU Make
+* Python 3 (for the wrapper step)
+
+On Debian/Ubuntu the toolchain can be installed with:
 
 ```bash
-make              # Build firmware.bin
+sudo apt-get update
+sudo apt-get install -y sdcc make python3
+```
+
+### Build steps
+
+```bash
+make              # Build build/firmware.bin
 make wrapped      # Build with ASM2464 header (checksum + CRC)
 make compare      # Compare against original fw.bin
+make clean        # Remove build artifacts
 ```
 
 ## Memory Map

--- a/src/app/stubs.c
+++ b/src/app/stubs.c
@@ -287,6 +287,20 @@ void helper_16e9(uint8_t param) { (void)param; }
 void helper_16eb(uint8_t param) { (void)param; }
 
 /*
+ * helper_173b - DMA/queue pointer helper used by SCSI path
+ * Address: 0x173b (entry point only)
+ *
+ * The original firmware tail-calls into a small routine that prepares
+ * DPTR before issuing a DMA-related request. The exact side effects are
+ * still unknown, but we stub it out so the firmware links and higher
+ * level logic can continue to be reverse engineered.
+ */
+void helper_173b(void)
+{
+    /* TODO: Implement once behavior at 0x173b is understood. */
+}
+
+/*
  * FUN_CODE_1b07 - Read from SCSI control array
  * Address: 0x1b07-0x1b13 (13 bytes)
  *


### PR DESCRIPTION
## Summary
- document SDCC-based local build steps for Debian/Ubuntu
- stub helper_173b so the firmware links successfully
- add a GitHub Actions workflow that installs SDCC, builds, and uploads firmware artifacts

## Testing
- make clean
- make
- make wrapped


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693730e9f44c83209051160abf578947)