### PR TITLE
Align PCIe queue queue handler with firmware idle waits

### DIFF
--- a/src/app/stubs.c
+++ b/src/app/stubs.c
@@ -1917,8 +1917,27 @@ void helper_e73a(void)
     FUN_CODE_e73a();
 }
 
-/* 0xe7ae: PCIe/DMA related - stub */
-void FUN_CODE_e7ae(void) {}
+/*
+ * handler_e7ae - UART/bridge transmit idle wait
+ * Address: 0xe7ae-0xe7bb
+ *
+ * Waits for the UART transmit FIFO and bridge interface to be idle before
+ * PCIe queue status is sampled. The original firmware polls until:
+ *   - REG_UART_TFBF bits[4:0] == 0x10 (TX buffer ready)
+ *   - REG_UART_STATUS_C00E bits[2:0] == 0   (bridge busy flags clear)
+ */
+void FUN_CODE_e7ae(void)
+{
+    uint8_t status;
+
+    do {
+        status = REG_UART_TFBF;
+    } while ((status & 0x1F) != 0x10);
+
+    do {
+        status = REG_UART_STATUS_C00E;
+    } while ((status & 0x07) != 0x00);
+}
 
 /* 0xe883: Handler - stub */
 void FUN_CODE_e883(void) {}

--- a/src/drivers/pcie.c
+++ b/src/drivers/pcie.c
@@ -2435,7 +2435,9 @@ extern void pcie_cleanup_05fc(void);                          /* 0x05fc - Cleanu
 extern void pcie_handler_e974(void);                          /* 0xe974 - Bank 1 handler */
 extern void pcie_handler_e06b(uint8_t param);                 /* 0xe06b - Bank 1 handler with param */
 extern void pcie_setup_a38b(uint8_t source);                  /* 0xa38b - Setup helper */
+extern void FUN_CODE_e7ae(void);                              /* 0xe7ae - UART/bridge idle wait */
 extern uint8_t pcie_get_status_a372(void);                    /* 0xa372 - Get status at 0x40 */
+uint8_t pcie_queue_handler_a62d(void);                        /* 0xa62d - Queue event handler */
 
 /*
  * pcie_interrupt_handler - Main PCIe interrupt handler
@@ -2661,7 +2663,9 @@ void pcie_interrupt_handler(void)
  */
 uint8_t pcie_queue_handler_a62d(void)
 {
-    /* Call bank 1 handler at 0xe7ae */
+    /* Ensure UART/bridge is idle before sampling link width */
+    FUN_CODE_e7ae();
+
     /* Read status from link width register, mask with 0xe0 */
     return REG_LINK_WIDTH_E710 & 0xe0;
 }

--- a/src/registers.h
+++ b/src/registers.h
@@ -290,6 +290,11 @@
 #define REG_UART_MCR            XDATA_REG8(0xC008)
 #define REG_UART_LSR            XDATA_REG8(0xC009)
 #define REG_UART_MSR            XDATA_REG8(0xC00A)
+/*
+ * Additional UART/bridge status register used for transmit gating.
+ * Bits 0-2 clear when the interface is idle.
+ */
+#define REG_UART_STATUS_C00E    XDATA_REG8(0xC00E)
 
 //=============================================================================
 // Link/PHY Control Registers (0xC200-0xC2FF)


### PR DESCRIPTION
## Summary
- add the missing UART status register used for queue polling
- implement handler_e7ae to wait for UART/bridge idle state
- call the idle wait from the PCIe queue handler before reading link width

## Testing
- make -j2

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693734f7f6a08320a9934ef55ee622ef)