### PR TITLE
Implement delay wrapper and register polling

### DIFF
--- a/src/app/state_helpers.c
+++ b/src/app/state_helpers.c
@@ -684,11 +684,20 @@ void flash_func_0bc8(void)
  */
 void reg_wait_bit_clear(uint16_t addr, uint8_t mask, uint8_t flags, uint8_t timeout)
 {
-    (void)addr;
-    (void)mask;
-    (void)flags;
-    (void)timeout;
-    /* TODO: Implement register polling with timeout */
+    /*
+     * Poll the target register until all bits in `mask` clear or the
+     * timeout counter expires. The original firmware uses R7 as a loop
+     * counter; here we mirror that behaviour by decrementing `timeout`
+     * after each failed check. The `flags` parameter is reserved for
+     * future mode tweaks; no alternate modes are known in the current
+     * reverse engineering pass, so it is ignored for now.
+     */
+    do {
+        uint8_t val = *(__xdata uint8_t *)addr;
+        if ((val & mask) == 0) {
+            return;
+        }
+    } while (timeout-- != 0);
 }
 
 /*

--- a/src/utils.c
+++ b/src/utils.c
@@ -923,6 +923,7 @@ void init_sys_flags_07f0(void)
 
 /* Forward declaration for loop helper */
 extern void delay_loop_adb0(void);
+extern void timer_wait(uint8_t timeout_lo, uint8_t timeout_hi, uint8_t mode);
 
 /*
  * delay_short_e89d - Short delay with IDATA setup
@@ -956,9 +957,14 @@ void delay_short_e89d(void)
  */
 void delay_wait_e80a(uint16_t delay, uint8_t flag)
 {
-    (void)delay;
-    (void)flag;
-    /* TODO: Implement timer-based delay */
+    /*
+     * This is a thin wrapper around timer_wait (0xE80A) using the
+     * calling convention from the original firmware where the low/high
+     * delay bytes are passed in R4/R5 and mode flags in R7.  The timer
+     * helper itself lives in timer.c; we simply forward the parameters
+     * so callers that reference the legacy symbol behave identically.
+     */
+    timer_wait((uint8_t)(delay & 0xFF), (uint8_t)(delay >> 8), flag);
 }
 
 /*


### PR DESCRIPTION
## Summary
- forward delay_wait_e80a to the timer_wait implementation so callers use the proper timer-based delay
- implement register bit clear polling with a timeout to mirror the original firmware behavior

## Testing
- make -s


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937368dbc908320a5d5a28e812748d3)