### PR TITLE
Fix USB2 firmware flashing and verification

### DIFF
--- a/handmade/e4_flash.py
+++ b/handmade/e4_flash.py
@@ -56,8 +56,24 @@ def flash_poll_busy(h):
     if not (xdata_read(h, 0xC8A9, 1)[0] & 0x01): return
   raise TimeoutError("Flash CSR busy timeout")
 
+def flash_clear_dma_status(h):
+  """Clear the DMA state used by flash reads."""
+  for addr in (0xC8B8, 0xC8B6, 0xC8D6, 0xC8D8):
+    xdata_write(h, addr, 0x00)
+
+def flash_poll_dma_idle(h):
+  """Wait until both flash DMA activity indicators are idle."""
+  for _ in range(100000):
+    if not (xdata_read(h, 0xC8B8, 1)[0] & 0x01) and not (xdata_read(h, 0xC8B6, 1)[0] & 0x80): return
+  raise TimeoutError("Flash DMA idle timeout")
+
 def flash_transaction(h, cmd, addr=0, data_len=0, addr_len=0x07, mode=0x00):
   """Run a flash transaction matching the stock bootloader sequence."""
+  is_read = data_len > 0 and not (mode & 0x01)
+  flash_poll_busy(h)
+  if is_read:
+    flash_clear_dma_status(h)
+    flash_poll_dma_idle(h)
   xdata_write(h, 0xC8AD, mode)
   xdata_write(h, 0xC8AE, 0x00)
   xdata_write(h, 0xC8AF, 0x00)
@@ -72,10 +88,15 @@ def flash_transaction(h, cmd, addr=0, data_len=0, addr_len=0x07, mode=0x00):
   xdata_write(h, 0xC8A4, data_len & 0xFF)
   xdata_write(h, 0xC8A9, 0x01)
   flash_poll_busy(h)
-  xdata_write(h, 0xC8AD, 0x00)
-  xdata_write(h, 0xC8AD, 0x00)
-  xdata_write(h, 0xC8AD, 0x00)
-  xdata_write(h, 0xC8AD, 0x00)
+  if is_read:
+    flash_poll_dma_idle(h)
+  # Keep these mode-bit clears as separate read-modify-write cycles.  The
+  # bootstub uses the same sequence because collapsing them corrupts reads.
+  for mask in (0x10, 0x20, 0x40, 0x80, 0x01):
+    current_mode = xdata_read(h, 0xC8AD, 1)[0]
+    xdata_write(h, 0xC8AD, current_mode & ~mask)
+  if is_read:
+    flash_clear_dma_status(h)
 
 def flash_wren(h):
   """WREN — write enable. Does NOT use flash_transaction to avoid clobbering 0x7000 buffer."""

--- a/handmade/e4_flash.py
+++ b/handmade/e4_flash.py
@@ -27,6 +27,9 @@ from pcie_probe import xdata_read, xdata_write
 
 VID, PID = 0x3801, 0x0001
 EP_OUT = 0x02
+FLASH_SIZE = 0x40000  # 256 KiB, matching JEDEC capacity code 0x12
+FLASH_BUFFER_SIZE = 4096
+FLASH_READ_PREFIX_SIZE = 1
 USB2_EP0_MAX_PACKET_SIZE = 64
 USB2_FLASH_WRITE_CHUNK_SIZE = 64
 VERIFY_CHUNK_SIZE = 256
@@ -124,21 +127,24 @@ def flash_jedec_id(h):
   return xdata_read(h, 0x7000, 3)
 
 def flash_read(h, addr, size):
-  """Read from SPI flash in 4KB DMA chunks, return requested bytes."""
+  """Read SPI flash while discarding the DMA buffer's unreliable first byte."""
   result = bytearray()
   offset = 0
   while offset < size:
-    want = min(4096, size - offset)
-    # DMA needs at least 4KB to fill buffer reliably
-    dma_len = max(4096, want)
-    flash_transaction(h, cmd=0x03, addr=addr + offset, data_len=dma_len, addr_len=0x07, mode=0x00)
+    want = min(FLASH_BUFFER_SIZE - FLASH_READ_PREFIX_SIZE, size - offset)
+    target_addr = (addr + offset) % FLASH_SIZE
+    dma_addr = (target_addr - FLASH_READ_PREFIX_SIZE) % FLASH_SIZE
+    # The first flash DMA byte can remain stale even after the controller
+    # reports idle.  Read one prefix byte and discard it.  Address zero wraps
+    # from the final byte of the 256 KiB flash.
+    flash_transaction(h, cmd=0x03, addr=dma_addr, data_len=FLASH_BUFFER_SIZE, addr_len=0x07, mode=0x00)
     read = 0
     while read < want:
       # The device may fall back from SuperSpeed to USB2, where the firmware
       # limits E4 control responses to one 64-byte EP0 packet.  Keep this
       # transport limit separate from the higher-level read/verify size.
       n = min(USB2_EP0_MAX_PACKET_SIZE, want - read)
-      chunk_addr = 0x7000 + read
+      chunk_addr = 0x7000 + FLASH_READ_PREFIX_SIZE + read
       chunk = xdata_read(h, chunk_addr, n)
       if len(chunk) != n:
         raise IOError(f"Short E4 read at 0x{chunk_addr:04X}: {len(chunk)}/{n} bytes")

--- a/handmade/e4_flash.py
+++ b/handmade/e4_flash.py
@@ -27,6 +27,8 @@ from pcie_probe import xdata_read, xdata_write
 
 VID, PID = 0x3801, 0x0001
 EP_OUT = 0x02
+USB2_EP0_MAX_PACKET_SIZE = 64
+VERIFY_CHUNK_SIZE = 256
 
 def flash_init(h):
   """Initialize flash controller — required before any SPI operation."""
@@ -110,8 +112,15 @@ def flash_read(h, addr, size):
     flash_transaction(h, cmd=0x03, addr=addr + offset, data_len=dma_len, addr_len=0x07, mode=0x00)
     read = 0
     while read < want:
-      n = min(255, want - read)
-      result.extend(xdata_read(h, 0x7000 + read, n))
+      # The device may fall back from SuperSpeed to USB2, where the firmware
+      # limits E4 control responses to one 64-byte EP0 packet.  Keep this
+      # transport limit separate from the higher-level read/verify size.
+      n = min(USB2_EP0_MAX_PACKET_SIZE, want - read)
+      chunk_addr = 0x7000 + read
+      chunk = xdata_read(h, chunk_addr, n)
+      if len(chunk) != n:
+        raise IOError(f"Short E4 read at 0x{chunk_addr:04X}: {len(chunk)}/{n} bytes")
+      result.extend(chunk)
       read += n
     offset += want
   return bytes(result)
@@ -185,7 +194,9 @@ def flash_verify(h, addr, firmware):
   errors = 0
   verified = 0
   while verified < total:
-    chunk = min(255, total - verified)
+    # Verification uses 256-byte logical windows. flash_read() splits each
+    # window into USB2-safe 64-byte E4 control transfers when necessary.
+    chunk = min(VERIFY_CHUNK_SIZE, total - verified)
     got = flash_read(h, addr + verified, chunk)
     expected = firmware[verified:verified + chunk]
     for i in range(min(len(got), len(expected))):

--- a/handmade/e4_flash.py
+++ b/handmade/e4_flash.py
@@ -28,6 +28,7 @@ from pcie_probe import xdata_read, xdata_write
 VID, PID = 0x3801, 0x0001
 EP_OUT = 0x02
 USB2_EP0_MAX_PACKET_SIZE = 64
+USB2_FLASH_WRITE_CHUNK_SIZE = 64
 VERIFY_CHUNK_SIZE = 256
 
 def flash_init(h):
@@ -168,17 +169,17 @@ def flash_write(h, addr, firmware):
   # Restore config if we saved it
   if config is not None:
     print("  Restoring config...")
-    for off in range(0, 256, 128):
-      chunk = config[off:off+128]
+    for off in range(0, len(config), USB2_FLASH_WRITE_CHUNK_SIZE):
+      chunk = config[off:off + USB2_FLASH_WRITE_CHUNK_SIZE]
       if not all(b == 0xFF for b in chunk):
         bulk_out(h, chunk)
-        flash_page_program(h, off, 128)
+        flash_page_program(h, off, len(chunk))
 
-  # Write in 128-byte chunks — 0x7000 buffer only reliably holds 128 bytes
-  # (upper half gets overwritten by firmware code/ISR)
+  # A USB2 bulk OUT may report success while only refreshing the first
+  # 64 bytes of the 0x7000 buffer, so stage each flash write separately.
   written = 0
   while written < total:
-    chunk_size = min(128, total - written)
+    chunk_size = min(USB2_FLASH_WRITE_CHUNK_SIZE, total - written)
     chunk = firmware[written:written + chunk_size]
     padded = chunk + bytes((-len(chunk)) % 4)
     bulk_out(h, padded)
@@ -225,28 +226,29 @@ def flash_test(h):
   # Erase
   print("  Erasing...")
   flash_block_erase(h, TEST_ADDR)
-  erased = flash_read(h, TEST_ADDR, 16)
-  assert all(b == 0xFF for b in erased), f"Erase failed: {erased.hex()}"
+  try:
+    erased = flash_read(h, TEST_ADDR, 16)
+    assert all(b == 0xFF for b in erased), f"Erase failed: {erased.hex()}"
 
-  # Write in 128-byte pages
-  print("  Writing...")
-  for off in range(0, TEST_SIZE, 128):
-    chunk = pattern[off:off+128]
-    bulk_out(h, chunk)
-    flash_page_program(h, TEST_ADDR + off, 128)
+    # Use the same USB2-safe write size as the firmware programming path.
+    print("  Writing...")
+    for off in range(0, TEST_SIZE, USB2_FLASH_WRITE_CHUNK_SIZE):
+      chunk = pattern[off:off + USB2_FLASH_WRITE_CHUNK_SIZE]
+      bulk_out(h, chunk)
+      flash_page_program(h, TEST_ADDR + off, len(chunk))
 
-  # Read back and verify
-  print("  Verifying...")
-  got = flash_read(h, TEST_ADDR, TEST_SIZE)
-  errors = 0
-  for i in range(TEST_SIZE):
-    if got[i] != pattern[i]:
-      if errors < 5:
-        print(f"    MISMATCH at +0x{i:04X}: got 0x{got[i]:02X}, expected 0x{pattern[i]:02X}")
-      errors += 1
-
-  # Clean up: re-erase the test block
-  flash_block_erase(h, TEST_ADDR)
+    # Read back and verify
+    print("  Verifying...")
+    got = flash_read(h, TEST_ADDR, TEST_SIZE)
+    errors = 0
+    for i in range(TEST_SIZE):
+      if got[i] != pattern[i]:
+        if errors < 5:
+          print(f"    MISMATCH at +0x{i:04X}: got 0x{got[i]:02X}, expected 0x{pattern[i]:02X}")
+        errors += 1
+  finally:
+    # Always leave the scratch block erased, including after test failures.
+    flash_block_erase(h, TEST_ADDR)
 
   if errors == 0:
     print(f"  PASS: {TEST_SIZE} bytes verified")

--- a/handmade/e4_flash.py
+++ b/handmade/e4_flash.py
@@ -30,6 +30,8 @@ EP_OUT = 0x02
 FLASH_SIZE = 0x40000  # 256 KiB, matching JEDEC capacity code 0x12
 FLASH_BUFFER_SIZE = 4096
 FLASH_READ_PREFIX_SIZE = 1
+FLASH_READ_CONFIRMATIONS = 2
+FLASH_READ_MAX_ATTEMPTS = 3
 USB2_EP0_MAX_PACKET_SIZE = 64
 USB2_FLASH_WRITE_CHUNK_SIZE = 64
 VERIFY_CHUNK_SIZE = 256
@@ -126,7 +128,7 @@ def flash_jedec_id(h):
   flash_transaction(h, cmd=0x9F, data_len=3, addr_len=0x04, mode=0x00)
   return xdata_read(h, 0x7000, 3)
 
-def flash_read(h, addr, size):
+def _flash_read_once(h, addr, size):
   """Read SPI flash while discarding the DMA buffer's unreliable first byte."""
   result = bytearray()
   offset = 0
@@ -152,6 +154,16 @@ def flash_read(h, addr, size):
       read += n
     offset += want
   return bytes(result)
+
+def flash_read(h, addr, size):
+  """Return a flash read only after two of three DMA samples agree."""
+  samples = {}
+  for _ in range(FLASH_READ_MAX_ATTEMPTS):
+    data = _flash_read_once(h, addr, size)
+    samples[data] = samples.get(data, 0) + 1
+    if samples[data] >= FLASH_READ_CONFIRMATIONS:
+      return data
+  raise IOError(f"Unstable flash read at 0x{addr:05X}: no two of {FLASH_READ_MAX_ATTEMPTS} samples matched")
 
 def flash_block_erase(h, addr):
   """Erase 64KB block."""

--- a/test/test_e4_flash.py
+++ b/test/test_e4_flash.py
@@ -32,7 +32,7 @@ def load_e4_flash(monkeypatch):
   return module
 
 
-def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
+def test_flash_read_once_splits_256_byte_read_into_usb2_packets(monkeypatch):
   """A 256-byte verification read must use four 64-byte E4 transfers."""
   e4_flash = load_e4_flash(monkeypatch)
   transactions = []
@@ -52,7 +52,7 @@ def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
 
   monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
 
-  result = e4_flash.flash_read(object(), 0x1234, 256)
+  result = e4_flash._flash_read_once(object(), 0x1234, 256)
 
   assert transactions == [{
     "cmd": 0x03,
@@ -70,7 +70,7 @@ def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
   assert result == bytes(range(256))
 
 
-def test_flash_read_wraps_prefix_for_address_zero(monkeypatch):
+def test_flash_read_once_wraps_prefix_for_address_zero(monkeypatch):
   """Address zero must use the last flash byte as the discarded prefix."""
   e4_flash = load_e4_flash(monkeypatch)
   transactions = []
@@ -90,7 +90,7 @@ def test_flash_read_wraps_prefix_for_address_zero(monkeypatch):
 
   monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
 
-  assert e4_flash.flash_read(object(), 0, len(expected)) == expected
+  assert e4_flash._flash_read_once(object(), 0, len(expected)) == expected
   assert transactions == [{
     "cmd": 0x03,
     "addr": e4_flash.FLASH_SIZE - 1,
@@ -101,7 +101,7 @@ def test_flash_read_wraps_prefix_for_address_zero(monkeypatch):
   assert reads == [(0x7001, len(expected))]
 
 
-def test_flash_read_keeps_prefix_with_full_buffer_request(monkeypatch):
+def test_flash_read_once_keeps_prefix_with_full_buffer_request(monkeypatch):
   """A 4 KiB request must split without reading past the DMA buffer."""
   e4_flash = load_e4_flash(monkeypatch)
   transactions = []
@@ -119,7 +119,7 @@ def test_flash_read_keeps_prefix_with_full_buffer_request(monkeypatch):
 
   monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
 
-  assert e4_flash.flash_read(object(), 0x100, 4096) == bytes(4096)
+  assert e4_flash._flash_read_once(object(), 0x100, 4096) == bytes(4096)
   assert [(transaction["addr"], transaction["data_len"]) for transaction in transactions] == [
     (0x0FF, 4096),
     (0x10FE, 4096),
@@ -150,13 +150,38 @@ def test_flash_verify_keeps_256_byte_comparison_windows(monkeypatch):
   ]
 
 
-def test_flash_read_rejects_short_usb2_control_read(monkeypatch):
+def test_flash_read_once_rejects_short_usb2_control_read(monkeypatch):
   e4_flash = load_e4_flash(monkeypatch)
   monkeypatch.setattr(e4_flash, "flash_transaction", lambda *_args, **_kwargs: None)
   monkeypatch.setattr(e4_flash, "xdata_read", lambda _handle, _addr, size: bytes(size - 1))
 
   with pytest.raises(IOError, match=r"Short E4 read at 0x7001: 63/64 bytes"):
-    e4_flash.flash_read(object(), 0, 64)
+    e4_flash._flash_read_once(object(), 0, 64)
+
+
+def test_flash_read_returns_sample_seen_twice(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  expected = bytes(range(16))
+  samples = iter((b"stale read sample", expected, expected))
+  calls = []
+
+  def fake_flash_read_once(_handle, addr, size):
+    calls.append((addr, size))
+    return next(samples)
+
+  monkeypatch.setattr(e4_flash, "_flash_read_once", fake_flash_read_once, raising=False)
+
+  assert e4_flash.flash_read(object(), 0x100, len(expected)) == expected
+  assert calls == [(0x100, len(expected))] * 3
+
+
+def test_flash_read_rejects_three_different_samples(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  samples = iter((b"sample-a", b"sample-b", b"sample-c"))
+  monkeypatch.setattr(e4_flash, "_flash_read_once", lambda *_args, **_kwargs: next(samples), raising=False)
+
+  with pytest.raises(IOError, match=r"Unstable flash read at 0x00100: no two of 3 samples matched"):
+    e4_flash.flash_read(object(), 0x100, 8)
 
 
 def test_flash_clear_dma_status_resets_all_activity_registers(monkeypatch):

--- a/test/test_e4_flash.py
+++ b/test/test_e4_flash.py
@@ -1,0 +1,97 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+E4_FLASH = PROJECT_ROOT / "handmade" / "e4_flash.py"
+
+
+def load_e4_flash(monkeypatch):
+  """Load e4_flash without tinygrad or physical USB hardware."""
+  tinygrad = types.ModuleType("tinygrad")
+  runtime = types.ModuleType("tinygrad.runtime")
+  autogen = types.ModuleType("tinygrad.runtime.autogen")
+  autogen.libusb = types.SimpleNamespace()
+  pcie_probe = types.ModuleType("pcie_probe")
+  pcie_probe.xdata_read = lambda *_args, **_kwargs: b""
+  pcie_probe.xdata_write = lambda *_args, **_kwargs: None
+
+  monkeypatch.setitem(sys.modules, "tinygrad", tinygrad)
+  monkeypatch.setitem(sys.modules, "tinygrad.runtime", runtime)
+  monkeypatch.setitem(sys.modules, "tinygrad.runtime.autogen", autogen)
+  monkeypatch.setitem(sys.modules, "pcie_probe", pcie_probe)
+
+  spec = importlib.util.spec_from_file_location("e4_flash_under_test", E4_FLASH)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
+  """A 256-byte verification read must use four 64-byte E4 transfers."""
+  e4_flash = load_e4_flash(monkeypatch)
+  transactions = []
+  reads = []
+
+  monkeypatch.setattr(
+    e4_flash,
+    "flash_transaction",
+    lambda _handle, **kwargs: transactions.append(kwargs),
+  )
+
+  def fake_xdata_read(_handle, addr, size):
+    reads.append((addr, size))
+    return bytes((addr + offset) & 0xFF for offset in range(size))
+
+  monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
+
+  result = e4_flash.flash_read(object(), 0x1234, 256)
+
+  assert transactions == [{
+    "cmd": 0x03,
+    "addr": 0x1234,
+    "data_len": 4096,
+    "addr_len": 0x07,
+    "mode": 0x00,
+  }]
+  assert reads == [
+    (0x7000, 64),
+    (0x7040, 64),
+    (0x7080, 64),
+    (0x70C0, 64),
+  ]
+  assert result == bytes(range(256))
+
+
+def test_flash_verify_keeps_256_byte_comparison_windows(monkeypatch):
+  """Transport packet sizing must not reduce the verification window."""
+  e4_flash = load_e4_flash(monkeypatch)
+  firmware = bytes(index & 0xFF for index in range(600))
+  reads = []
+
+  def fake_flash_read(_handle, addr, size):
+    reads.append((addr, size))
+    offset = addr - 0x100
+    return firmware[offset:offset + size]
+
+  monkeypatch.setattr(e4_flash, "flash_read", fake_flash_read)
+
+  assert e4_flash.flash_verify(object(), 0x100, firmware) == 0
+  assert reads == [
+    (0x100, 256),
+    (0x200, 256),
+    (0x300, 88),
+  ]
+
+
+def test_flash_read_rejects_short_usb2_control_read(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  monkeypatch.setattr(e4_flash, "flash_transaction", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(e4_flash, "xdata_read", lambda _handle, _addr, size: bytes(size - 1))
+
+  with pytest.raises(IOError, match=r"Short E4 read at 0x7000: 63/64 bytes"):
+    e4_flash.flash_read(object(), 0, 64)

--- a/test/test_e4_flash.py
+++ b/test/test_e4_flash.py
@@ -37,6 +37,7 @@ def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
   e4_flash = load_e4_flash(monkeypatch)
   transactions = []
   reads = []
+  flash_data = bytes(index & 0xFF for index in range(320))
 
   monkeypatch.setattr(
     e4_flash,
@@ -46,7 +47,8 @@ def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
 
   def fake_xdata_read(_handle, addr, size):
     reads.append((addr, size))
-    return bytes((addr + offset) & 0xFF for offset in range(size))
+    offset = addr - 0x7001
+    return flash_data[offset:offset + size]
 
   monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
 
@@ -54,18 +56,77 @@ def test_flash_read_splits_256_byte_read_into_usb2_packets(monkeypatch):
 
   assert transactions == [{
     "cmd": 0x03,
-    "addr": 0x1234,
+    "addr": 0x1233,
     "data_len": 4096,
     "addr_len": 0x07,
     "mode": 0x00,
   }]
   assert reads == [
-    (0x7000, 64),
-    (0x7040, 64),
-    (0x7080, 64),
-    (0x70C0, 64),
+    (0x7001, 64),
+    (0x7041, 64),
+    (0x7081, 64),
+    (0x70C1, 64),
   ]
   assert result == bytes(range(256))
+
+
+def test_flash_read_wraps_prefix_for_address_zero(monkeypatch):
+  """Address zero must use the last flash byte as the discarded prefix."""
+  e4_flash = load_e4_flash(monkeypatch)
+  transactions = []
+  reads = []
+  expected = bytes(range(16))
+
+  monkeypatch.setattr(
+    e4_flash,
+    "flash_transaction",
+    lambda _handle, **kwargs: transactions.append(kwargs),
+  )
+
+  def fake_xdata_read(_handle, addr, size):
+    reads.append((addr, size))
+    assert addr == 0x7001
+    return expected[:size]
+
+  monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
+
+  assert e4_flash.flash_read(object(), 0, len(expected)) == expected
+  assert transactions == [{
+    "cmd": 0x03,
+    "addr": e4_flash.FLASH_SIZE - 1,
+    "data_len": 4096,
+    "addr_len": 0x07,
+    "mode": 0x00,
+  }]
+  assert reads == [(0x7001, len(expected))]
+
+
+def test_flash_read_keeps_prefix_with_full_buffer_request(monkeypatch):
+  """A 4 KiB request must split without reading past the DMA buffer."""
+  e4_flash = load_e4_flash(monkeypatch)
+  transactions = []
+  reads = []
+
+  monkeypatch.setattr(
+    e4_flash,
+    "flash_transaction",
+    lambda _handle, **kwargs: transactions.append(kwargs),
+  )
+
+  def fake_xdata_read(_handle, addr, size):
+    reads.append((addr, size))
+    return bytes(size)
+
+  monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
+
+  assert e4_flash.flash_read(object(), 0x100, 4096) == bytes(4096)
+  assert [(transaction["addr"], transaction["data_len"]) for transaction in transactions] == [
+    (0x0FF, 4096),
+    (0x10FE, 4096),
+  ]
+  assert reads[0] == (0x7001, 64)
+  assert reads[63] == (0x7FC1, 63)
+  assert reads[64] == (0x7001, 1)
 
 
 def test_flash_verify_keeps_256_byte_comparison_windows(monkeypatch):
@@ -94,7 +155,7 @@ def test_flash_read_rejects_short_usb2_control_read(monkeypatch):
   monkeypatch.setattr(e4_flash, "flash_transaction", lambda *_args, **_kwargs: None)
   monkeypatch.setattr(e4_flash, "xdata_read", lambda _handle, _addr, size: bytes(size - 1))
 
-  with pytest.raises(IOError, match=r"Short E4 read at 0x7000: 63/64 bytes"):
+  with pytest.raises(IOError, match=r"Short E4 read at 0x7001: 63/64 bytes"):
     e4_flash.flash_read(object(), 0, 64)
 
 

--- a/test/test_e4_flash.py
+++ b/test/test_e4_flash.py
@@ -1,4 +1,5 @@
 import importlib.util
+import random
 import sys
 import types
 from pathlib import Path
@@ -95,3 +96,88 @@ def test_flash_read_rejects_short_usb2_control_read(monkeypatch):
 
   with pytest.raises(IOError, match=r"Short E4 read at 0x7000: 63/64 bytes"):
     e4_flash.flash_read(object(), 0, 64)
+
+
+def test_flash_write_uses_usb2_safe_chunks_for_config_and_firmware(monkeypatch):
+  """Config restoration and firmware writes must stay within 64 bytes."""
+  e4_flash = load_e4_flash(monkeypatch)
+  config = bytes(range(256))
+  firmware = bytes(range(130))
+  erased = []
+  bulk_writes = []
+  page_programs = []
+
+  monkeypatch.setattr(e4_flash, "flash_read", lambda _handle, addr, size: config if (addr, size) == (0, 256) else None)
+  monkeypatch.setattr(e4_flash, "flash_block_erase", lambda _handle, addr: erased.append(addr))
+  monkeypatch.setattr(e4_flash, "bulk_out", lambda _handle, data: bulk_writes.append(bytes(data)))
+  monkeypatch.setattr(
+    e4_flash,
+    "flash_page_program",
+    lambda _handle, addr, size: page_programs.append((addr, size)),
+  )
+
+  e4_flash.flash_write(object(), 0x100, firmware)
+
+  assert erased == [0]
+  assert [len(chunk) for chunk in bulk_writes] == [64, 64, 64, 64, 64, 64, 4]
+  assert bulk_writes[-1] == firmware[-2:] + b"\x00\x00"
+  assert page_programs == [
+    (0x000, 64),
+    (0x040, 64),
+    (0x080, 64),
+    (0x0C0, 64),
+    (0x100, 64),
+    (0x140, 64),
+    (0x180, 2),
+  ]
+
+
+def test_flash_test_uses_usb2_safe_chunks(monkeypatch):
+  """The destructive flash self-test must use the same safe write size."""
+  e4_flash = load_e4_flash(monkeypatch)
+  rng = random.Random(42)
+  pattern = bytes(rng.randint(0, 255) for _ in range(4096))
+  erased = []
+  bulk_sizes = []
+  page_programs = []
+
+  def fake_flash_read(_handle, _addr, size):
+    if size == 16:
+      return b"\xFF" * size
+    if size == len(pattern):
+      return pattern
+    raise AssertionError(f"Unexpected flash read size: {size}")
+
+  monkeypatch.setattr(e4_flash, "flash_read", fake_flash_read)
+  monkeypatch.setattr(e4_flash, "flash_block_erase", lambda _handle, addr: erased.append(addr))
+  monkeypatch.setattr(e4_flash, "bulk_out", lambda _handle, data: bulk_sizes.append(len(data)))
+  monkeypatch.setattr(
+    e4_flash,
+    "flash_page_program",
+    lambda _handle, addr, size: page_programs.append((addr, size)),
+  )
+
+  assert e4_flash.flash_test(object()) == 0
+  assert erased == [0x10000, 0x10000]
+  assert bulk_sizes == [64] * 64
+  assert page_programs == [(0x10000 + offset, 64) for offset in range(0, 4096, 64)]
+
+
+def test_flash_test_erases_scratch_block_after_write_failure(monkeypatch):
+  """A failed self-test must still erase its scratch flash block."""
+  e4_flash = load_e4_flash(monkeypatch)
+  erased = []
+
+  monkeypatch.setattr(e4_flash, "flash_read", lambda _handle, _addr, size: b"\xFF" * size)
+  monkeypatch.setattr(e4_flash, "flash_block_erase", lambda _handle, addr: erased.append(addr))
+  monkeypatch.setattr(e4_flash, "bulk_out", lambda *_args, **_kwargs: None)
+
+  def fail_page_program(*_args, **_kwargs):
+    raise IOError("simulated page program failure")
+
+  monkeypatch.setattr(e4_flash, "flash_page_program", fail_page_program)
+
+  with pytest.raises(IOError, match="simulated page program failure"):
+    e4_flash.flash_test(object())
+
+  assert erased == [0x10000, 0x10000]

--- a/test/test_e4_flash.py
+++ b/test/test_e4_flash.py
@@ -98,6 +98,77 @@ def test_flash_read_rejects_short_usb2_control_read(monkeypatch):
     e4_flash.flash_read(object(), 0, 64)
 
 
+def test_flash_clear_dma_status_resets_all_activity_registers(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  writes = []
+  monkeypatch.setattr(e4_flash, "xdata_write", lambda _handle, addr, value: writes.append((addr, value)))
+
+  e4_flash.flash_clear_dma_status(object())
+
+  assert writes == [
+    (0xC8B8, 0),
+    (0xC8B6, 0),
+    (0xC8D6, 0),
+    (0xC8D8, 0),
+  ]
+
+
+def test_flash_poll_dma_idle_waits_for_both_activity_bits(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  trigger = iter((0x01, 0x00, 0x00))
+  channel = iter((0x80, 0x00))
+
+  def fake_xdata_read(_handle, addr, size):
+    assert size == 1
+    if addr == 0xC8B8:
+      return bytes([next(trigger)])
+    if addr == 0xC8B6:
+      return bytes([next(channel)])
+    raise AssertionError(f"Unexpected DMA register: 0x{addr:04X}")
+
+  monkeypatch.setattr(e4_flash, "xdata_read", fake_xdata_read)
+
+  e4_flash.flash_poll_dma_idle(object())
+
+
+def test_flash_transaction_waits_for_read_dma_and_clears_mode_bits(monkeypatch):
+  e4_flash = load_e4_flash(monkeypatch)
+  events = []
+  registers = {}
+  mode_writes = []
+
+  monkeypatch.setattr(e4_flash, "flash_poll_busy", lambda _handle: events.append("flash_busy"))
+  monkeypatch.setattr(e4_flash, "flash_clear_dma_status", lambda _handle: events.append("dma_clear"), raising=False)
+  monkeypatch.setattr(e4_flash, "flash_poll_dma_idle", lambda _handle: events.append("dma_idle"), raising=False)
+
+  def fake_xdata_write(_handle, addr, value):
+    registers[addr] = value
+    if addr == 0xC8AD:
+      mode_writes.append(value)
+
+  monkeypatch.setattr(e4_flash, "xdata_write", fake_xdata_write)
+  monkeypatch.setattr(e4_flash, "xdata_read", lambda _handle, addr, _size: bytes([registers.get(addr, 0)]))
+
+  e4_flash.flash_transaction(
+    object(),
+    cmd=0x03,
+    addr=0x100,
+    data_len=4096,
+    addr_len=0x07,
+    mode=0xF0,
+  )
+
+  assert events == [
+    "flash_busy",
+    "dma_clear",
+    "dma_idle",
+    "flash_busy",
+    "dma_idle",
+    "dma_clear",
+  ]
+  assert mode_writes == [0xF0, 0xE0, 0xC0, 0x80, 0x00, 0x00]
+
+
 def test_flash_write_uses_usb2_safe_chunks_for_config_and_firmware(monkeypatch):
   """Config restoration and firmware writes must stay within 64 bytes."""
   e4_flash = load_e4_flash(monkeypatch)


### PR DESCRIPTION
## Problem

ASM2464PD is USB 3.x capable, but it can negotiate USB2 High-Speed (480 Mbps) depending on the cable, port, or link state. Firmware installation and verification were unreliable in that mode for three separate reasons:

- E4 XDATA reads are limited to one 64-byte EP0 packet, while the host requested up to 255 bytes per control transfer. This can end in a libusb `-7` timeout.
- A 128-byte bulk OUT can report success even though only the first 64 bytes refresh the flash staging buffer. Programming those chunks corrupts roughly half of the image.
- Flash DMA can expose a stale first byte even after its busy indicators clear. This produces sparse, varying verification mismatches and can corrupt the configuration copied around a block erase.

The 64-byte limit is a USB2 transport constraint. Firmware verification remains a separate 256-byte logical comparison window.

## Changes

- Split E4 control reads into USB2-safe 64-byte transfers while retaining 256-byte verification windows.
- Split firmware, configuration restore, and self-test writes into independently staged 64-byte operations.
- Synchronize flash read DMA using the bootstub status sequence and separate mode-bit clears.
- Read and discard one DMA prefix byte, including wraparound at flash address zero.
- Accept a flash read only after two of up to three complete samples match.
- Reject short E4 responses immediately.
- Always erase the self-test scratch block, including on failure.
- Add regression coverage for USB2 read/write chunking, DMA synchronization, stale-prefix handling, stable reads, verification windows, and cleanup behavior.

## Validation

- `pytest -q` — 168 passed, 1 skipped
- `python3 -m compileall -q handmade/e4_flash.py`
- GitHub Actions `build` and `test` — passed
- Real ASM2464PD hardware negotiated at USB2 High-Speed (480 Mbps):
  - Original PR self-test: 2,039 mismatches out of 4,096 bytes, first mismatch at offset `0x0040`
  - Updated self-test: 4,096 bytes passed; scratch block confirmed erased afterward
  - Clean `4a270a1d-CLEAN` firmware: 9,143-byte flash and built-in verification passed
  - Two additional read-only verifications passed before reset
  - Cold power-cycle enumerated as `3801:0001 tiny custom 4a270a1d-CLEAN`
  - Cold-boot read-only firmware verification passed with zero mismatches
  - The 256-byte configuration matched the pre-flash backup before and after flashing and cold boot
