### PR TITLE
add low-priority tick interrupt, uptime and PSU fault latch 

### DIFF
--- a/handmade/src/main.c
+++ b/handmade/src/main.c
@@ -411,6 +411,7 @@ static void handle_usb_control(void) {
   }
 }
 
+
 /*=== ISR ===*/
 
 void handle_usb_bulk_data(void) {
@@ -544,6 +545,7 @@ void main(void) {
   // Bring USB up. force_usb2=0: try SS first, fall back via LINK_EVENT.
   usb_init_controller(0);
 
+  // configure 10 Hz system timer
   REG_TIMER3_CSR = TIMER_CSR_CLEAR;
   REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
   REG_TIMER3_DIV = (REG_TIMER3_DIV & 0xE8) | SYSTEM_TIMER_MODE;
@@ -552,6 +554,7 @@ void main(void) {
   REG_TIMER3_CSR = TIMER_CSR_ENABLE;
   REG_INT_ENABLE |= INT_ENABLE_SYSTEM;
 
+  // enable interrupts
   IP = IP_PX0;
   IE = IE_EA | IE_EX0 | IE_EX1;
 

--- a/handmade/src/main.c
+++ b/handmade/src/main.c
@@ -10,12 +10,14 @@
 
 __sfr __at(0x93) DPX;   /* DPTR bank select — DPX=1 accesses internal PHY regs */
 __sfr __at(0xA8) IE;
+__sfr __at(0xB8) IP;
 __sfr __at(0x88) TCON;
 
 #define IE_EA   0x80
 #define IE_EX1  0x04
-#define IE_ET0  0x02
 #define IE_EX0  0x01
+
+#define IP_PX0  0x01 /* External interrupt 0 (USB) high priority */
 
 // blocking version: void uart_putc(uint8_t ch) { while (!REG_UART_TFBF); REG_UART_THR = ch; }
 void uart_putc(uint8_t ch) { REG_UART_THR = ch; }
@@ -51,8 +53,30 @@ static uint32_t dma_dwords;    /* total dwords remaining for streaming transfer 
 typedef struct {
   uint16_t voltage_mv;   /* INA231 bus voltage */
   int16_t  current_ma;   /* INA231 shunt current (signed) */
-  bool     bob_flt;      /* BOB fault asserted (active-low GPIO 1) */
+  bool     psu_fault;    /* PSU fault seen since the previous status read */
+  uint32_t uptime_s;     /* Whole seconds since firmware initialization */
 } hw_status_t;
+
+static bool psu_fault_latched;
+static uint8_t subsecond_ticks;
+static uint32_t uptime_s;
+
+static void psu_fault_poll(void) {
+  if (!gpio_read(GPIO_BOB_FLT_N)) psu_fault_latched = true;
+}
+
+#define SYSTEM_TICK_HZ             10U
+#define SYSTEM_TIMER_MODE          0x04U /* 0.5 ms per count */
+#define SYSTEM_TIMER_COUNTS        200U  /* 100 ms */
+
+static void system_timer_start(void) {
+  REG_TIMER3_CSR = TIMER_CSR_CLEAR;
+  REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
+  REG_TIMER3_DIV = (REG_TIMER3_DIV & 0xE8) | SYSTEM_TIMER_MODE;
+  REG_TIMER3_THRESHOLD_HI = SYSTEM_TIMER_COUNTS >> 8;
+  REG_TIMER3_THRESHOLD_LO = SYSTEM_TIMER_COUNTS & 0xFF;
+  REG_TIMER3_CSR = TIMER_CSR_ENABLE;
+}
 
 static void hw_status_read(__xdata hw_status_t *s) {
   uint16_t shunt_raw = 0, bus_raw = 0;
@@ -61,7 +85,10 @@ static void hw_status_read(__xdata hw_status_t *s) {
   s->voltage_mv = (uint16_t)(((uint32_t)bus_raw * 125) / 100);               /* 1.25 mV/LSB */
   s->current_ma = (int16_t)(((int32_t)(int16_t)shunt_raw * 2500)             /* shunt uV × 1000 */
                             / INA231_SHUNT_UOHM);                            /* / R (uOhm) = mA */
-  s->bob_flt = gpio_read(GPIO_BOB_FLT_N) ? false : true;
+  psu_fault_poll();
+  s->psu_fault = psu_fault_latched;
+  psu_fault_latched = false;
+  s->uptime_s = uptime_s;
 }
 
 static void pcie_power_off(void) {
@@ -484,8 +511,22 @@ void int0_isr(void) __interrupt(0) {
   }
 }
 
-void int1_isr(void) __interrupt(1) {
-  uart_puts("[int1]\n");
+void int1_isr(void) __interrupt(2) {
+  uint8_t system_status = REG_INT_SYSTEM;
+  if (system_status & INT_SYSTEM_EVENT) {
+    /* Timer 3 is one-shot.  Re-arm first to minimize tick-to-tick skew. */
+    REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
+    REG_TIMER3_CSR = TIMER_CSR_ENABLE;
+    psu_fault_poll();
+    if (++subsecond_ticks == SYSTEM_TICK_HZ) {
+      subsecond_ticks = 0;
+      /* A 32-bit increment is not atomic on the 8051.  Briefly mask all
+       * interrupts so high-priority USB cannot observe a torn value. */
+      IE &= (uint8_t)~IE_EA;
+      uptime_s++;
+      IE |= IE_EA;
+    }
+  }
 }
 
 void main(void) {
@@ -513,8 +554,13 @@ void main(void) {
   // Bring USB up. force_usb2=0: try SS first, fall back via LINK_EVENT.
   usb_init_controller(0);
 
-  // enable interrupts
-  IE = IE_EA | IE_EX0 | IE_EX1 | IE_ET0;
+  system_timer_start();
+  REG_INT_ENABLE |= INT_ENABLE_SYSTEM;
+
+  /* Keep the timer/system EX1 at low priority.  USB EX0 is high priority and
+   * can preempt the short PSU-fault sampling handler. */
+  IP = IP_PX0;
+  IE = IE_EA | IE_EX0 | IE_EX1;
 
   i2c_init();
   ina231_init();
@@ -523,4 +569,3 @@ void main(void) {
     // DO NOT PUT ANYTHING HERE, EVERYTHING SHOULD BE HANDLED IN INTERRUPTS
   }
 }
-

--- a/handmade/src/main.c
+++ b/handmade/src/main.c
@@ -408,7 +408,6 @@ static void handle_usb_control(void) {
   }
 }
 
-
 /*=== ISR ===*/
 
 void handle_usb_bulk_data(void) {
@@ -563,3 +562,4 @@ void main(void) {
     // DO NOT PUT ANYTHING HERE, EVERYTHING SHOULD BE HANDLED IN INTERRUPTS
   }
 }
+

--- a/handmade/src/main.c
+++ b/handmade/src/main.c
@@ -56,21 +56,19 @@ static uint32_t dma_dwords;    /* total dwords remaining for streaming transfer 
 typedef struct {
   uint16_t voltage_mv;   /* INA231 bus voltage */
   int16_t  current_ma;   /* INA231 shunt current (signed) */
-  bool     psu_fault;    /* PSU fault seen since the previous status read */
+  bool     psu_fault;    /* Current PSU fault state */
+  bool     psu_fault_latched; /* Held high for five seconds */
   uint32_t uptime_s;     /* Whole seconds since firmware initialization */
 } hw_status_t;
 
-static volatile bool psu_fault_latched;
+static volatile uint8_t psu_fault_latch_ticks;
 static uint8_t subsecond_ticks;
 static volatile uint32_t uptime_s;
-
-static void psu_fault_poll(void) {
-  if (!gpio_read(GPIO_BOB_FLT_N)) psu_fault_latched = true;
-}
 
 #define SYSTEM_TICK_HZ      10U
 #define SYSTEM_TIMER_MODE   0x04U
 #define SYSTEM_TIMER_COUNTS 200U
+#define PSU_FAULT_LATCH_TICKS (5U * SYSTEM_TICK_HZ)
 
 static void hw_status_read(__xdata hw_status_t *s) {
   uint16_t shunt_raw = 0, bus_raw = 0;
@@ -79,9 +77,8 @@ static void hw_status_read(__xdata hw_status_t *s) {
   s->voltage_mv = (uint16_t)(((uint32_t)bus_raw * 125) / 100);               /* 1.25 mV/LSB */
   s->current_ma = (int16_t)(((int32_t)(int16_t)shunt_raw * 2500)             /* shunt uV × 1000 */
                             / INA231_SHUNT_UOHM);                            /* / R (uOhm) = mA */
-  psu_fault_poll();
-  s->psu_fault = psu_fault_latched;
-  psu_fault_latched = false;
+  s->psu_fault = !gpio_read(GPIO_BOB_FLT_N);
+  s->psu_fault_latched = s->psu_fault || psu_fault_latch_ticks;
   s->uptime_s = uptime_s;
 }
 
@@ -510,7 +507,8 @@ void int1_isr(void) __interrupt(2) {
   if (REG_INT_SYSTEM & INT_SYSTEM_EVENT) {
     REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
     REG_TIMER3_CSR = TIMER_CSR_ENABLE;
-    psu_fault_poll();
+    if (!gpio_read(GPIO_BOB_FLT_N)) psu_fault_latch_ticks = PSU_FAULT_LATCH_TICKS;
+    else if (psu_fault_latch_ticks) psu_fault_latch_ticks--;
     if (++subsecond_ticks == SYSTEM_TICK_HZ) {
       subsecond_ticks = 0;
       DISABLE_INTERRUPTS();

--- a/handmade/src/main.c
+++ b/handmade/src/main.c
@@ -17,7 +17,10 @@ __sfr __at(0x88) TCON;
 #define IE_EX1  0x04
 #define IE_EX0  0x01
 
-#define IP_PX0  0x01 /* External interrupt 0 (USB) high priority */
+#define DISABLE_INTERRUPTS() (IE &= (uint8_t)~IE_EA)
+#define ENABLE_INTERRUPTS()  (IE |= IE_EA)
+
+#define IP_PX0  0x01
 
 // blocking version: void uart_putc(uint8_t ch) { while (!REG_UART_TFBF); REG_UART_THR = ch; }
 void uart_putc(uint8_t ch) { REG_UART_THR = ch; }
@@ -57,26 +60,17 @@ typedef struct {
   uint32_t uptime_s;     /* Whole seconds since firmware initialization */
 } hw_status_t;
 
-static bool psu_fault_latched;
+static volatile bool psu_fault_latched;
 static uint8_t subsecond_ticks;
-static uint32_t uptime_s;
+static volatile uint32_t uptime_s;
 
 static void psu_fault_poll(void) {
   if (!gpio_read(GPIO_BOB_FLT_N)) psu_fault_latched = true;
 }
 
-#define SYSTEM_TICK_HZ             10U
-#define SYSTEM_TIMER_MODE          0x04U /* 0.5 ms per count */
-#define SYSTEM_TIMER_COUNTS        200U  /* 100 ms */
-
-static void system_timer_start(void) {
-  REG_TIMER3_CSR = TIMER_CSR_CLEAR;
-  REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
-  REG_TIMER3_DIV = (REG_TIMER3_DIV & 0xE8) | SYSTEM_TIMER_MODE;
-  REG_TIMER3_THRESHOLD_HI = SYSTEM_TIMER_COUNTS >> 8;
-  REG_TIMER3_THRESHOLD_LO = SYSTEM_TIMER_COUNTS & 0xFF;
-  REG_TIMER3_CSR = TIMER_CSR_ENABLE;
-}
+#define SYSTEM_TICK_HZ      10U
+#define SYSTEM_TIMER_MODE   0x04U
+#define SYSTEM_TIMER_COUNTS 200U
 
 static void hw_status_read(__xdata hw_status_t *s) {
   uint16_t shunt_raw = 0, bus_raw = 0;
@@ -512,19 +506,15 @@ void int0_isr(void) __interrupt(0) {
 }
 
 void int1_isr(void) __interrupt(2) {
-  uint8_t system_status = REG_INT_SYSTEM;
-  if (system_status & INT_SYSTEM_EVENT) {
-    /* Timer 3 is one-shot.  Re-arm first to minimize tick-to-tick skew. */
+  if (REG_INT_SYSTEM & INT_SYSTEM_EVENT) {
     REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
     REG_TIMER3_CSR = TIMER_CSR_ENABLE;
     psu_fault_poll();
     if (++subsecond_ticks == SYSTEM_TICK_HZ) {
       subsecond_ticks = 0;
-      /* A 32-bit increment is not atomic on the 8051.  Briefly mask all
-       * interrupts so high-priority USB cannot observe a torn value. */
-      IE &= (uint8_t)~IE_EA;
+      DISABLE_INTERRUPTS();
       uptime_s++;
-      IE |= IE_EA;
+      ENABLE_INTERRUPTS();
     }
   }
 }
@@ -554,11 +544,14 @@ void main(void) {
   // Bring USB up. force_usb2=0: try SS first, fall back via LINK_EVENT.
   usb_init_controller(0);
 
-  system_timer_start();
+  REG_TIMER3_CSR = TIMER_CSR_CLEAR;
+  REG_TIMER3_CSR = TIMER_CSR_EXPIRED;
+  REG_TIMER3_DIV = (REG_TIMER3_DIV & 0xE8) | SYSTEM_TIMER_MODE;
+  REG_TIMER3_THRESHOLD_HI = SYSTEM_TIMER_COUNTS >> 8;
+  REG_TIMER3_THRESHOLD_LO = SYSTEM_TIMER_COUNTS & 0xFF;
+  REG_TIMER3_CSR = TIMER_CSR_ENABLE;
   REG_INT_ENABLE |= INT_ENABLE_SYSTEM;
 
-  /* Keep the timer/system EX1 at low priority.  USB EX0 is high priority and
-   * can preempt the short PSU-fault sampling handler. */
   IP = IP_PX0;
   IE = IE_EA | IE_EX0 | IE_EX1;
 

--- a/handmade/src/registers.h
+++ b/handmade/src/registers.h
@@ -1736,9 +1736,11 @@
 #define REG_TIMER2_THRESHOLD    XDATA_REG16(0xCC1E)
 #define REG_TIMER2_THRESHOLD_LO XDATA_REG8(0xCC1E)  /* Timer 2 threshold low */
 #define REG_TIMER2_THRESHOLD_HI XDATA_REG8(0xCC1F)  /* Timer 2 threshold high */
-#define REG_TIMER3_DIV          XDATA_REG8(0xCC22)
-#define REG_TIMER3_CSR          XDATA_REG8(0xCC23)
-#define REG_TIMER3_IDLE_TIMEOUT XDATA_REG8(0xCC24)
+#define REG_TIMER3_DIV          XDATA_REG8(0xCC22)  /* Mode 4: 0.5 ms per threshold count */
+#define REG_TIMER3_CSR          XDATA_REG8(0xCC23)  /* One-shot; expiry raises C806 bit 0 / EX1 */
+#define REG_TIMER3_THRESHOLD_HI XDATA_REG8(0xCC24)  /* 16-bit threshold, high byte */
+#define REG_TIMER3_THRESHOLD_LO XDATA_REG8(0xCC25)  /* 16-bit threshold, low byte */
+#define REG_TIMER3_IDLE_TIMEOUT REG_TIMER3_THRESHOLD_HI /* Legacy name; threshold is 16-bit. */
 
 //=============================================================================
 // CPU Control Extended (0xCC30-0xCCFF)

--- a/handmade/src/registers.h
+++ b/handmade/src/registers.h
@@ -1737,10 +1737,9 @@
 #define REG_TIMER2_THRESHOLD_LO XDATA_REG8(0xCC1E)  /* Timer 2 threshold low */
 #define REG_TIMER2_THRESHOLD_HI XDATA_REG8(0xCC1F)  /* Timer 2 threshold high */
 #define REG_TIMER3_DIV          XDATA_REG8(0xCC22)  /* Mode 4: 0.5 ms per threshold count */
-#define REG_TIMER3_CSR          XDATA_REG8(0xCC23)  /* One-shot; expiry raises C806 bit 0 / EX1 */
-#define REG_TIMER3_THRESHOLD_HI XDATA_REG8(0xCC24)  /* 16-bit threshold, high byte */
-#define REG_TIMER3_THRESHOLD_LO XDATA_REG8(0xCC25)  /* 16-bit threshold, low byte */
-#define REG_TIMER3_IDLE_TIMEOUT REG_TIMER3_THRESHOLD_HI /* Legacy name; threshold is 16-bit. */
+#define REG_TIMER3_CSR          XDATA_REG8(0xCC23)  /* One-shot, raises INT_SYSTEM_EVENT on expiry */
+#define REG_TIMER3_THRESHOLD_HI XDATA_REG8(0xCC24)  /* Timer 3 threshold high byte */
+#define REG_TIMER3_THRESHOLD_LO XDATA_REG8(0xCC25)  /* Timer 3 threshold low byte */
 
 //=============================================================================
 // CPU Control Extended (0xCC30-0xCCFF)

--- a/scripts/hw_status.py
+++ b/scripts/hw_status.py
@@ -4,7 +4,8 @@
   bRequest 0xC0 IN -> hw_status_t {
     uint16_t voltage_mv;  // INA231 bus voltage
     int16_t  current_ma;  // INA231 shunt current (signed)
-    bool     psu_fault;   // PSU fault seen since the previous status read
+    bool     psu_fault;   // current PSU fault state
+    bool     psu_fault_latched;  // held high for five seconds
     uint32_t uptime_s;    // whole seconds since firmware initialization
   }
 """
@@ -23,7 +24,7 @@ SUPPORTED_CONTROLLERS = [
 ]
 
 HW_STATUS_REQ = 0xC0
-HW_STATUS_FORMAT = "<HhBI"
+HW_STATUS_FORMAT = "<HhBBI"
 HW_STATUS_LEN = struct.calcsize(HW_STATUS_FORMAT)
 
 
@@ -59,8 +60,8 @@ def read_hw_status(dev, timeout_ms=1000):
     data = bytes(dev.ctrl_transfer(0xC0, HW_STATUS_REQ, 0, 0, HW_STATUS_LEN, timeout=timeout_ms))
     if len(data) != HW_STATUS_LEN:
         raise RuntimeError(f"short hw_status read: expected {HW_STATUS_LEN}, got {len(data)}")
-    voltage_mv, current_ma, psu_fault, uptime_s = struct.unpack(HW_STATUS_FORMAT, data)
-    return voltage_mv, current_ma, bool(psu_fault), uptime_s
+    voltage_mv, current_ma, psu_fault, psu_fault_latched, uptime_s = struct.unpack(HW_STATUS_FORMAT, data)
+    return voltage_mv, current_ma, bool(psu_fault), bool(psu_fault_latched), uptime_s
 
 
 def fmt_timestamp(now=None):
@@ -88,8 +89,8 @@ def main():
     setup_device(dev)
 
     print(f"Device {vid:04X}:{pid:04X}", flush=True)
-    print("time             V[V]    I[A]     P[W]  PSU_FLT  UPTIME[s]", flush=True)
-    print("------------  -------  ------  -------  -------  ---------", flush=True)
+    print("time             V[V]    I[A]     P[W]  PSU_FLT  PSU_FLT_5S  UPTIME[s]", flush=True)
+    print("------------  -------  ------  -------  -------  ----------  ---------", flush=True)
 
     interval_s = args.interval_ms / 1000.0
     next_sample = time.monotonic()
@@ -101,12 +102,13 @@ def main():
                 time.sleep(next_sample - now)
 
             wall_now = time.time()
-            v_mv, i_ma, psu_fault, uptime_s = read_hw_status(dev)
+            v_mv, i_ma, psu_fault, psu_fault_latched, uptime_s = read_hw_status(dev)
             v = v_mv / 1000.0
             a = i_ma / 1000.0
             print(
                 f"{fmt_timestamp(wall_now)}  {v:7.3f}  {a:+6.3f}  {v*a:+7.3f}"
-                f"  {'yes' if psu_fault else 'no':>7}  {uptime_s:9d}",
+                f"  {'yes' if psu_fault else 'no':>7}"
+                f"  {'yes' if psu_fault_latched else 'no':>10}  {uptime_s:9d}",
                 flush=True,
             )
 

--- a/scripts/hw_status.py
+++ b/scripts/hw_status.py
@@ -4,7 +4,8 @@
   bRequest 0xC0 IN -> hw_status_t {
     uint16_t voltage_mv;  // INA231 bus voltage
     int16_t  current_ma;  // INA231 shunt current (signed)
-    bool     bob_flt;     // BOB fault asserted
+    bool     psu_fault;   // PSU fault seen since the previous status read
+    uint32_t uptime_s;    // whole seconds since firmware initialization
   }
 """
 
@@ -22,7 +23,7 @@ SUPPORTED_CONTROLLERS = [
 ]
 
 HW_STATUS_REQ = 0xC0
-HW_STATUS_FORMAT = "<HhB"
+HW_STATUS_FORMAT = "<HhBI"
 HW_STATUS_LEN = struct.calcsize(HW_STATUS_FORMAT)
 
 
@@ -58,8 +59,8 @@ def read_hw_status(dev, timeout_ms=1000):
     data = bytes(dev.ctrl_transfer(0xC0, HW_STATUS_REQ, 0, 0, HW_STATUS_LEN, timeout=timeout_ms))
     if len(data) != HW_STATUS_LEN:
         raise RuntimeError(f"short hw_status read: expected {HW_STATUS_LEN}, got {len(data)}")
-    voltage_mv, current_ma, bob_flt = struct.unpack(HW_STATUS_FORMAT, data)
-    return voltage_mv, current_ma, bool(bob_flt)
+    voltage_mv, current_ma, psu_fault, uptime_s = struct.unpack(HW_STATUS_FORMAT, data)
+    return voltage_mv, current_ma, bool(psu_fault), uptime_s
 
 
 def fmt_timestamp(now=None):
@@ -87,8 +88,8 @@ def main():
     setup_device(dev)
 
     print(f"Device {vid:04X}:{pid:04X}", flush=True)
-    print("time             V[V]    I[A]     P[W]  BOB_FLT", flush=True)
-    print("------------  -------  ------  -------  -------", flush=True)
+    print("time             V[V]    I[A]     P[W]  PSU_FLT  UPTIME[s]", flush=True)
+    print("------------  -------  ------  -------  -------  ---------", flush=True)
 
     interval_s = args.interval_ms / 1000.0
     next_sample = time.monotonic()
@@ -100,12 +101,12 @@ def main():
                 time.sleep(next_sample - now)
 
             wall_now = time.time()
-            v_mv, i_ma, bob_flt = read_hw_status(dev)
+            v_mv, i_ma, psu_fault, uptime_s = read_hw_status(dev)
             v = v_mv / 1000.0
             a = i_ma / 1000.0
             print(
                 f"{fmt_timestamp(wall_now)}  {v:7.3f}  {a:+6.3f}  {v*a:+7.3f}"
-                f"  {'yes' if bob_flt else 'no':>7}",
+                f"  {'yes' if psu_fault else 'no':>7}  {uptime_s:9d}",
                 flush=True,
             )
 


### PR DESCRIPTION
__interrupt(1) was wrongly defined as int1, it was the tim1 interrupt which we don't use.